### PR TITLE
Do not use syntax highlighting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: swagger
 Type: Package
 Title: Dynamically Generates Documentation from a 'Swagger' Compliant API
-Version: 3.33.0
+Version: 3.33.0.9000
 Authors@R: c(
     person("Barret", "Schloerke", email = "barret@rstudio.com", role = c("cre", "aut")),
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Swagger (development)
+
+- Disable syntax highlighting to allow larger response bodies to not freeze the browser (#19)
+
 # Swagger 3.33.0
 
 - Adds support for Swagger 3.33.0

--- a/inst/dist3/index.html
+++ b/inst/dist3/index.html
@@ -41,12 +41,13 @@
       const ui = SwaggerUIBundle({
         url: "https://petstore.swagger.io/v2/swagger.json",
         validatorUrl: null, // disable validation
-        dom_id: '#swagger-ui',
-        deepLinking: true,
+        // https://github.com/rstudio/swagger/pull/19
         syntaxHighlight: {
           activated: false,
           theme: "agate"
         },
+        dom_id: '#swagger-ui',
+        deepLinking: true,
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset

--- a/inst/dist3/index.html
+++ b/inst/dist3/index.html
@@ -43,6 +43,10 @@
         validatorUrl: null, // disable validation
         dom_id: '#swagger-ui',
         deepLinking: true,
+        syntaxHighlight: {
+          activated: false,
+          theme: "agate"
+        },
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset

--- a/tools/download_swagger_ui.R
+++ b/tools/download_swagger_ui.R
@@ -36,7 +36,7 @@ local({
     res == 0
   })
 
-  # shim in `validateUrl: null,`
+  # shim in rstudio/swagger config settings
   index_html_file <- file.path(to_location, "index.html")
   index_html <- readLines(index_html_file)
   petstore_line <- which(grepl("https://petstore.swagger.io/v2/swagger.json", index_html, fixed = TRUE))
@@ -44,7 +44,14 @@ local({
 
   updated_html <- append(
     index_html,
-    "        validatorUrl: null, // disable validation",
+    c(
+      "        validatorUrl: null, // disable validation",
+      "        // https://github.com/rstudio/swagger/pull/19",
+      "        syntaxHighlight: {",
+      "          activated: false,",
+      "          theme: \"agate\"",
+      "        },"
+    ),
     after = petstore_line
   )
   writeLines(updated_html, index_html_file)


### PR DESCRIPTION
swagger-ui is VERY slow when displaying non-trivially sized response bodies. WAY too many DOM manipulations.

See: https://github.com/swagger-api/swagger-ui/issues/3832

Fix taken from : https://github.com/swagger-api/swagger-ui/issues/3832#issuecomment-698531637

`theme: "agate"` is used as it is the default theme used: https://github.com/swagger-api/swagger-ui/blob/a73783b73d30f509cff89731fe71b1c81f75c689/src/core/components/highlight-code.jsx#L44